### PR TITLE
refactor: Simplify S3 Terraform for raw-only data architecture

### DIFF
--- a/infra/terraform/s3/variables.tf
+++ b/infra/terraform/s3/variables.tf
@@ -27,15 +27,6 @@ variable "raw_glacier_days" {
   default = 180
 }
 
-variable "bronze_ia_days" {
-  type    = number
-  default = 30
-}
-
-variable "silver_ia_days" {
-  type    = number
-  default = 30
-}
 
 variable "enable_versioning" {
   type    = bool
@@ -54,7 +45,3 @@ variable "create_writer_policy" {
   default = true
 }
 
-variable "writer_principal_arn" {
-  type    = string
-  default = ""
-}

--- a/infra/terraform/s3/versions.tf
+++ b/infra/terraform/s3/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   # float within v1.x but require a reasonably new core
-  required_version = ">= 1.11.0, < 2.0.0"
+  required_version = ">= 1.0.0, < 2.0.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
- Remove bronze/silver/gold lifecycle rules
- Update IAM policy to restrict access to raw/slack/* prefix only
- Remove unused variables (bronze_ia_days, silver_ia_days, writer_principal_arn)
- Fix Terraform version constraint to support v1.9.0