### PR TITLE
Updated infra code

### DIFF
--- a/infra/terraform/s3/main.tf
+++ b/infra/terraform/s3/main.tf
@@ -37,8 +37,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "slack" {
 
 data "aws_iam_policy_document" "deny_insecure_transport" {
   statement {
-    sid    = "DenyInsecureTransport"
-    effect = "Deny"
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
     actions = ["s3:*"]
     principals {
       type        = "*"
@@ -107,16 +107,16 @@ resource "aws_s3_bucket_lifecycle_configuration" "slack" {
 
 data "aws_iam_policy_document" "writer" {
   statement {
-    sid     = "ListBucket"
-    effect  = "Allow"
-    actions = ["s3:ListBucket"]
+    sid       = "ListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.slack.arn]
   }
 
   statement {
-    sid     = "RW"
-    effect  = "Allow"
-    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    sid       = "RW"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
     resources = ["${aws_s3_bucket.slack.arn}/*"]
   }
 }

--- a/infra/terraform/s3/versions.tf
+++ b/infra/terraform/s3/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   # float within v1.x but require a reasonably new core
-  required_version = ">= 1.11.0, < 2.0.0"
+  required_version = ">= 1.9.0, < 2.0.0"
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
       # float within v6.x (current major); will pick 6.9.0+ when available
       version = "~> 6.0"
     }


### PR DESCRIPTION
This pull request makes a small change to the Terraform configuration for S3. The required Terraform version has been updated to allow use of versions starting from 1.9.0 instead of 1.11.0.