### PR TITLE
feat: Add IAM role management for Slack S3 upload workflow

### DIFF
--- a/.github/workflows/01-terraform-deploy.yml
+++ b/.github/workflows/01-terraform-deploy.yml
@@ -77,6 +77,9 @@ jobs:
         run: |
           terraform plan -var="bucket_name=${{ env.BUCKET_DATA }}" \
                         -var="aws_region=${{ env.AWS_REGION }}" \
+                        -var="github_repo=${{ github.repository }}" \
+                        -var="github_environment=dev" \
+                        -var="slack_s3_writer_role_name=${{ vars.SLACK_S3_WRITER_ROLE_NAME }}" \
                         -out=tfplan
                         
       - name: Upload Terraform Plan
@@ -92,7 +95,10 @@ jobs:
         run: |
           terraform apply -auto-approve \
                          -var="bucket_name=${{ env.BUCKET_DATA }}" \
-                         -var="aws_region=${{ env.AWS_REGION }}"
+                         -var="aws_region=${{ env.AWS_REGION }}" \
+                         -var="github_repo=${{ github.repository }}" \
+                         -var="github_environment=dev" \
+                         -var="slack_s3_writer_role_name=${{ vars.SLACK_S3_WRITER_ROLE_NAME }}"
                          
       - name: Terraform Destroy
         if: github.event.inputs.action == 'destroy'
@@ -100,7 +106,10 @@ jobs:
         run: |
           terraform destroy -auto-approve \
                            -var="bucket_name=${{ env.BUCKET_DATA }}" \
-                           -var="aws_region=${{ env.AWS_REGION }}"
+                           -var="aws_region=${{ env.AWS_REGION }}" \
+                           -var="github_repo=${{ github.repository }}" \
+                           -var="github_environment=dev" \
+                           -var="slack_s3_writer_role_name=${{ vars.SLACK_S3_WRITER_ROLE_NAME }}"
                            
       - name: Output Summary
         if: always()

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/infra/terraform/s3/outputs.tf
+++ b/infra/terraform/s3/outputs.tf
@@ -9,3 +9,13 @@ output "bucket_arn" {
 output "writer_policy_arn" {
   value = try(aws_iam_policy.writer[0].arn, null)
 }
+
+output "slack_s3_writer_role_arn" {
+  value       = try(aws_iam_role.slack_s3_writer[0].arn, null)
+  description = "ARN of the IAM role for Slack S3 writer"
+}
+
+output "slack_s3_writer_role_name" {
+  value       = try(aws_iam_role.slack_s3_writer[0].name, null)
+  description = "Name of the IAM role for Slack S3 writer"
+}

--- a/infra/terraform/s3/variables.tf
+++ b/infra/terraform/s3/variables.tf
@@ -58,3 +58,27 @@ variable "writer_principal_arn" {
   type    = string
   default = ""
 }
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository in format owner/repo"
+  default     = "sparsh-raj/dtc-llm-slack-faq-enhancer"
+}
+
+variable "github_environment" {
+  type        = string
+  description = "GitHub environment name"
+  default     = "dev"
+}
+
+variable "slack_s3_writer_role_name" {
+  type        = string
+  description = "Name of the IAM role for Slack S3 writer"
+  default     = "gha-dlt-ingestion-dev"
+}
+
+variable "create_slack_writer_role" {
+  type        = bool
+  description = "Whether to create the Slack S3 writer IAM role"
+  default     = true
+}


### PR DESCRIPTION
- Add GitHub OIDC trust policy for secure role assumption
- Create IAM role for Slack data ingestion with S3 write permissions
- Update terraform workflow to pass new role configuration variables
- Add role outputs for ARN and name reference

This enables the 03-slack-raw-upload-s3 workflow to assume the proper IAM role for uploading Slack data to S3 without long-lived credentials.