### PR TITLE
fix: Handle existing IAM role to prevent creation conflicts

### DIFF
--- a/infra/terraform/s3/main.tf
+++ b/infra/terraform/s3/main.tf
@@ -151,8 +151,17 @@ data "aws_iam_policy_document" "github_oidc_trust" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_role" "existing_slack_s3_writer" {
+  count = var.create_slack_writer_role ? 1 : 0
+  name  = var.slack_s3_writer_role_name
+}
+
+locals {
+  role_exists = var.create_slack_writer_role && length(data.aws_iam_role.existing_slack_s3_writer) > 0 && data.aws_iam_role.existing_slack_s3_writer[0].name != ""
+}
+
 resource "aws_iam_role" "slack_s3_writer" {
-  count              = var.create_slack_writer_role ? 1 : 0
+  count              = var.create_slack_writer_role && !local.role_exists ? 1 : 0
   name               = var.slack_s3_writer_role_name
   assume_role_policy = data.aws_iam_policy_document.github_oidc_trust.json
   description        = "Role for GitHub Actions to upload Slack data to S3"
@@ -160,7 +169,9 @@ resource "aws_iam_role" "slack_s3_writer" {
 }
 
 resource "aws_iam_role_policy_attachment" "slack_s3_writer" {
-  count      = var.create_slack_writer_role && var.create_writer_policy ? 1 : 0
-  role       = aws_iam_role.slack_s3_writer[0].name
+  count = var.create_slack_writer_role && var.create_writer_policy ? 1 : 0
+  role = local.role_exists ? 
+    data.aws_iam_role.existing_slack_s3_writer[0].name : 
+    aws_iam_role.slack_s3_writer[0].name
   policy_arn = aws_iam_policy.writer[0].arn
 }

--- a/infra/terraform/s3/outputs.tf
+++ b/infra/terraform/s3/outputs.tf
@@ -11,11 +11,19 @@ output "writer_policy_arn" {
 }
 
 output "slack_s3_writer_role_arn" {
-  value       = try(aws_iam_role.slack_s3_writer[0].arn, null)
+  value = var.create_slack_writer_role ? (
+    local.role_exists ? 
+    data.aws_iam_role.existing_slack_s3_writer[0].arn : 
+    try(aws_iam_role.slack_s3_writer[0].arn, null)
+  ) : null
   description = "ARN of the IAM role for Slack S3 writer"
 }
 
 output "slack_s3_writer_role_name" {
-  value       = try(aws_iam_role.slack_s3_writer[0].name, null)
+  value = var.create_slack_writer_role ? (
+    local.role_exists ? 
+    data.aws_iam_role.existing_slack_s3_writer[0].name : 
+    try(aws_iam_role.slack_s3_writer[0].name, null)
+  ) : null
   description = "Name of the IAM role for Slack S3 writer"
 }


### PR DESCRIPTION
- Add data source to check for existing IAM role
- Only create role if it doesn't already exist
- Attach S3 policy to existing or newly created role
- Update outputs to handle both scenarios

This prevents EntityAlreadyExists errors when the role already exists in AWS while still ensuring proper policy attachment.