### PR TITLE
Disabled the FAQ reader for empty FAQ docs

### DIFF
--- a/.github/workflows/04-read-faq.yml
+++ b/.github/workflows/04-read-faq.yml
@@ -22,7 +22,7 @@ env:
   FAQ_DOC_LLM_ZOOMCAMP: ${{ secrets.FAQ_DOC_LLM_ZOOMCAMP }}
   FAQ_DOC_MLOPS_ZOOMCAMP: ${{ secrets.FAQ_DOC_MLOPS_ZOOMCAMP }}
   FAQ_DOC_ML_ZOOMCAMP: ${{ secrets.FAQ_DOC_ML_ZOOMCAMP }}
-  FAQ_DOC_STOCKS_ANALYTICS: ${{ secrets.FAQ_DOC_STOCKS_ANALYTICS }}
+  # FAQ_DOC_STOCKS_ANALYTICS: ${{ secrets.FAQ_DOC_STOCKS_ANALYTICS }}
   
   # Qdrant Configuration
   QDRANT_URL: ${{ secrets.QDRANT_URL }}
@@ -93,7 +93,7 @@ jobs:
               -e FAQ_DOC_LLM_ZOOMCAMP \
               -e FAQ_DOC_MLOPS_ZOOMCAMP \
               -e FAQ_DOC_ML_ZOOMCAMP \
-              -e FAQ_DOC_STOCKS_ANALYTICS \
+              # -e FAQ_DOC_STOCKS_ANALYTICS \
               -e QDRANT_URL \
               -e QDRANT_API_KEY \
               -e QDRANT_BASE_COLLECTION \
@@ -112,7 +112,7 @@ jobs:
               -e FAQ_DOC_LLM_ZOOMCAMP \
               -e FAQ_DOC_MLOPS_ZOOMCAMP \
               -e FAQ_DOC_ML_ZOOMCAMP \
-              -e FAQ_DOC_STOCKS_ANALYTICS \
+              # -e FAQ_DOC_STOCKS_ANALYTICS \
               -e QDRANT_URL \
               -e QDRANT_API_KEY \
               -e QDRANT_BASE_COLLECTION \

--- a/data-ingestion/pipeline/faq_courses.yml
+++ b/data-ingestion/pipeline/faq_courses.yml
@@ -22,10 +22,10 @@ faq_courses:
     google_doc_id: "${FAQ_DOC_ML_ZOOMCAMP}"
     collection_suffix: "ml_zoomcamp"
     
-  - id: course-stocks-analytics-zoomcamp
-    name: "Stocks Analytics Zoomcamp"
-    google_doc_id: "${FAQ_DOC_STOCKS_ANALYTICS}"
-    collection_suffix: "stocks_analytics"
+  # - id: course-stocks-analytics-zoomcamp
+  #   name: "Stocks Analytics Zoomcamp"
+  #   google_doc_id: "${FAQ_DOC_STOCKS_ANALYTICS}"
+  #   collection_suffix: "stocks_analytics"
 
 # Global settings
 settings:


### PR DESCRIPTION
This pull request removes the configuration and environment variables related to the "Stocks Analytics Zoomcamp" course from both the GitHub Actions workflow and the FAQ courses pipeline. This streamlines the setup by commenting out all references to this course, ensuring it is no longer processed or required in the deployment.

**Workflow and pipeline configuration cleanup:**

* Commented out the `FAQ_DOC_STOCKS_ANALYTICS` secret from the environment variables in `.github/workflows/04-read-faq.yml`, so it is no longer required for workflow execution.
* Commented out the `-e FAQ_DOC_STOCKS_ANALYTICS` environment variable in two places within the workflow job steps in `.github/workflows/04-read-faq.yml`, preventing it from being passed to the container. [[1]](diffhunk://#diff-269038906785d2bfc537f3105f87750fde62d35d40b26e3c2280e805e4cab6a4L96-R96) [[2]](diffhunk://#diff-269038906785d2bfc537f3105f87750fde62d35d40b26e3c2280e805e4cab6a4L115-R115)

**FAQ pipeline configuration update:**

* Commented out the entire configuration block for the "Stocks Analytics Zoomcamp" course in `data-ingestion/pipeline/faq_courses.yml`, ensuring it is excluded from FAQ ingestion.