### PR TITLE
fix: Correct Docker FROM/AS keyword casing for BuildKit compatibility

### DIFF
--- a/data-ingestion/Dockerfile
+++ b/data-ingestion/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for DTC FAQ Reader - Hybrid Search
 # Pre-caches both dense and sparse ML models for faster runtime
 
-FROM python:3.12-slim as base
+FROM python:3.12-slim AS base
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
- Change 'as' to 'AS' in FROM statement to match Docker best practices
- Resolves FromAsCasing lint error in buildx builds
- Ensures consistent keyword casing required by modern Docker BuildKit