### PR TITLE
fix: Remove broken commented line in Docker command that caused syntax error

### DIFF
--- a/.github/workflows/04-read-faq.yml
+++ b/.github/workflows/04-read-faq.yml
@@ -96,7 +96,6 @@ jobs:
               -e FAQ_DOC_LLM_ZOOMCAMP \
               -e FAQ_DOC_MLOPS_ZOOMCAMP \
               -e FAQ_DOC_ML_ZOOMCAMP \
-              # -e FAQ_DOC_STOCKS_ANALYTICS \
               -e QDRANT_URL \
               -e QDRANT_API_KEY \
               -e QDRANT_BASE_COLLECTION \
@@ -115,7 +114,6 @@ jobs:
               -e FAQ_DOC_LLM_ZOOMCAMP \
               -e FAQ_DOC_MLOPS_ZOOMCAMP \
               -e FAQ_DOC_ML_ZOOMCAMP \
-              # -e FAQ_DOC_STOCKS_ANALYTICS \
               -e QDRANT_URL \
               -e QDRANT_API_KEY \
               -e QDRANT_BASE_COLLECTION \


### PR DESCRIPTION
- Remove commented FAQ_DOC_STOCKS_ANALYTICS line that broke multi-line Docker command
- Fix 'docker run requires at least 1 argument' error in GitHub Actions workflow