### PR TITLE
perf: Optimize Docker builds and GitHub Actions for disk space management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,28 @@ infra/
 *.log
 errors.txt
 artifacts/
+tmp/
+temp/
+*.tmp
+
+# Exclude test files to reduce context
+tests/
+*_test.py
+test_*.py
+
+# Exclude large model files (downloaded during build)
+*.bin
+*.safetensors
+*.onnx
+*.pkl
+models/
+
+# Exclude virtual environments and caches
+venv/
+env/
+ENV/
+.coverage*
+htmlcov/
 
 # Only include what's needed for FAQ reader:
 # - pyproject.toml

--- a/.github/workflows/04-read-faq.yml
+++ b/.github/workflows/04-read-faq.yml
@@ -47,6 +47,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free Disk Space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
+          echo "After cleanup:"
+          df -h
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v3
 
@@ -68,6 +80,12 @@ jobs:
           platforms: linux/amd64
           provenance: false
           sbom: false
+
+      - name: Check disk usage after build
+        run: df -h
+
+      - name: Clean Docker build cache
+        run: docker builder prune -f
 
       - name: Auth to Google via OIDC
         uses: google-github-actions/auth@v2

--- a/data-ingestion/Dockerfile
+++ b/data-ingestion/Dockerfile
@@ -14,22 +14,29 @@ RUN apt-get update && apt-get install -y \
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Set up Python environment
+# Set up Python environment and optimized cache locations
 WORKDIR /models
+
+# Set cache directories to temporary locations for smaller image size
+ENV TRANSFORMERS_CACHE=/tmp/transformers
+ENV SENTENCE_TRANSFORMERS_HOME=/tmp/sentence_transformers
+ENV HF_HOME=/tmp/huggingface
 
 # Install dependencies using the gdoc-faq dependency group
 COPY pyproject.toml uv.lock ./
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
-RUN uv sync --frozen --no-install-project --group gdoc-faq && \
+RUN uv sync --frozen --no-install-project --group gdoc-faq --no-cache && \
     uv pip install --system --no-cache-dir \
-    torch --extra-index-url https://download.pytorch.org/whl/cpu
+    torch --extra-index-url https://download.pytorch.org/whl/cpu && \
+    uv cache clean
 
-# Pre-download models with error handling and timeout
+# Pre-download models with error handling, timeout, and optimized caching
 RUN echo "Downloading dense embedding model..." && \
-    timeout 300 python -c "from sentence_transformers import SentenceTransformer; print('Loading model...', flush=True); SentenceTransformer('multi-qa-mpnet-base-dot-v1'); print('Dense model cached!', flush=True)"
-
-RUN echo "Downloading sparse embedding model..." && \
-    timeout 300 python -c "from fastembed import SparseTextEmbedding; print('Loading SPLADE...', flush=True); SparseTextEmbedding('prithivida/Splade_PP_en_v1'); print('Sparse model cached!', flush=True)"
+    timeout 300 python -c "from sentence_transformers import SentenceTransformer; print('Loading model...', flush=True); SentenceTransformer('multi-qa-mpnet-base-dot-v1'); print('Dense model cached!', flush=True)" && \
+    echo "Downloading sparse embedding model..." && \
+    timeout 300 python -c "from fastembed import SparseTextEmbedding; print('Loading SPLADE...', flush=True); SparseTextEmbedding('prithivida/Splade_PP_en_v1'); print('Sparse model cached!', flush=True)" && \
+    echo "Models downloaded successfully" && \
+    du -sh /tmp/transformers /tmp/sentence_transformers /tmp/huggingface 2>/dev/null || echo "Cache directories size check completed"
 
 # Stage 2: Runtime stage
 FROM python:3.12-slim AS runtime
@@ -46,14 +53,23 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy Python packages and models from builder stage
+# Copy Python packages from builder stage (optimized cache handling)
 COPY --from=model-downloader /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=model-downloader /root/.cache /root/.cache
+COPY --from=model-downloader /tmp/transformers /tmp/transformers
+COPY --from=model-downloader /tmp/sentence_transformers /tmp/sentence_transformers
+COPY --from=model-downloader /tmp/huggingface /tmp/huggingface
+
+# Set runtime cache environment variables
+ENV TRANSFORMERS_CACHE=/tmp/transformers
+ENV SENTENCE_TRANSFORMERS_HOME=/tmp/sentence_transformers
+ENV HF_HOME=/tmp/huggingface
 
 # Create non-root user and set permissions
 RUN groupadd -r appuser && useradd -r -g appuser -m appuser \
     && chown -R appuser:appuser /app \
-    && chown -R appuser:appuser /root/.cache
+    && chown -R appuser:appuser /tmp/transformers \
+    && chown -R appuser:appuser /tmp/sentence_transformers \
+    && chown -R appuser:appuser /tmp/huggingface
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
- Add disk cleanup step to free ~14GB before Docker operations
- Implement optimized model caching using /tmp directories
- Enhance .dockerignore to exclude test files and large binaries
- Add disk usage monitoring and build cache cleanup in workflow
- Combine model downloads into single Docker layer for efficiency
- Clean UV package cache to reduce image size

Addresses "No space left on device" errors in GitHub Actions runners.