### PR TITLE
fix: Create cache directories before copying in Docker build

### DIFF
--- a/data-ingestion/Dockerfile
+++ b/data-ingestion/Dockerfile
@@ -22,6 +22,9 @@ ENV TRANSFORMERS_CACHE=/tmp/transformers
 ENV SENTENCE_TRANSFORMERS_HOME=/tmp/sentence_transformers
 ENV HF_HOME=/tmp/huggingface
 
+# Create cache directories
+RUN mkdir -p /tmp/transformers /tmp/sentence_transformers /tmp/huggingface
+
 # Install dependencies using the gdoc-faq dependency group
 COPY pyproject.toml uv.lock ./
 ENV UV_PROJECT_ENVIRONMENT=/usr/local


### PR DESCRIPTION
Ensures /tmp/transformers, /tmp/sentence_transformers, and /tmp/huggingface directories exist before COPY operations to prevent "not found" build errors.